### PR TITLE
Refactored a ton of switches in Matcher and Codon class itself

### DIFF
--- a/src/Matcher.cs
+++ b/src/Matcher.cs
@@ -6,17 +6,200 @@ namespace DRPTranslatorCS
     /// <summary>
     /// This class contains several matcher methods which convert characters into their matching DNA or RNA bases
     /// </summary>
-    class GeneticMatcher
+    static class GeneticMatcher
     {
+        static readonly Dictionary<AA, List<Codon>> _dic = new Dictionary<AA, List<Codon>>()
+        {
+            {
+                AA.ALA, new List<Codon>()
+                {
+                    new Codon(RNA.G, RNA.C, RNA.U),
+                    new Codon(RNA.G, RNA.C, RNA.C),
+                    new Codon(RNA.G, RNA.C, RNA.A),
+                    new Codon(RNA.G, RNA.C, RNA.G)
+                }
+            },
+            {
+                AA.ARG, new List<Codon>()
+                {
+                    new Codon(RNA.C, RNA.G, RNA.U),
+                    new Codon(RNA.C, RNA.G, RNA.C),
+                    new Codon(RNA.C, RNA.G, RNA.A),
+                    new Codon(RNA.C, RNA.G, RNA.G),
+                    new Codon(RNA.A, RNA.G, RNA.A),
+                    new Codon(RNA.A, RNA.G, RNA.G)
+                }
+            },
+            {
+                AA.ASN, new List<Codon>()
+                {
+                    new Codon(RNA.A, RNA.A, RNA.U),
+                    new Codon(RNA.A, RNA.A, RNA.C)
+                }
+            },
+            {
+                AA.ASP, new List<Codon>()
+                {
+                    new Codon(RNA.G, RNA.A, RNA.U),
+                    new Codon(RNA.G, RNA.A, RNA.C)
+                }
+            },
+            {
+                AA.CYS, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.G, RNA.U),
+                    new Codon(RNA.U, RNA.G, RNA.C)
+                }
+            },
+            {
+                AA.GLN, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.G, RNA.U),
+                    new Codon(RNA.U, RNA.G, RNA.C)
+                }
+            },
+            {
+                AA.GLU, new List<Codon>()
+                {
+                    new Codon(RNA.G, RNA.A, RNA.A),
+                    new Codon(RNA.G, RNA.A, RNA.G)
+                }
+            },
+            {
+                AA.GLY, new List<Codon>()
+                {
+                    new Codon(RNA.G, RNA.G, RNA.U),
+                    new Codon(RNA.G, RNA.G, RNA.C),
+                    new Codon(RNA.G, RNA.G, RNA.A),
+                    new Codon(RNA.G, RNA.G, RNA.G)
+                }
+            },
+            {
+                AA.HIS, new List<Codon>()
+                {
+                    new Codon(RNA.C, RNA.A, RNA.U),
+                    new Codon(RNA.C, RNA.A, RNA.C)
+                }
+            },
+            {
+                AA.LEU, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.U, RNA.A),
+                    new Codon(RNA.U, RNA.U, RNA.G),
+                    new Codon(RNA.C, RNA.U, RNA.U),
+                    new Codon(RNA.C, RNA.U, RNA.C),
+                    new Codon(RNA.C, RNA.U, RNA.A),
+                    new Codon(RNA.C, RNA.U, RNA.G)
+                }
+            },
+            {
+                AA.LYS, new List<Codon>()
+                {
+                    new Codon(RNA.A, RNA.A, RNA.A),
+                    new Codon(RNA.A, RNA.A, RNA.G)
+                }
+            },
+            {
+                AA.MET, new List<Codon>()
+                {
+                    new Codon(RNA.A, RNA.U, RNA.G)
+                }
+            },
+            {
+                AA.PHE, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.U, RNA.U),
+                    new Codon(RNA.U, RNA.U, RNA.C)
+                }
+            },
+            {
+                AA.PRO, new List<Codon>()
+                {
+                    new Codon(RNA.C, RNA.C, RNA.U),
+                    new Codon(RNA.C, RNA.C, RNA.C),
+                    new Codon(RNA.C, RNA.C, RNA.A),
+                    new Codon(RNA.C, RNA.C, RNA.G)
+                }
+            },
+            {
+                AA.SER, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.C, RNA.U),
+                    new Codon(RNA.U, RNA.C, RNA.C),
+                    new Codon(RNA.U, RNA.C, RNA.A),
+                    new Codon(RNA.U, RNA.C, RNA.G),
+                    new Codon(RNA.A, RNA.G, RNA.U),
+                    new Codon(RNA.A, RNA.G, RNA.C)
+                }
+            },
+            {
+                AA.THR, new List<Codon>()
+                {
+                    new Codon(RNA.C, RNA.C, RNA.U),
+                    new Codon(RNA.C, RNA.C, RNA.C),
+                    new Codon(RNA.C, RNA.C, RNA.A),
+                    new Codon(RNA.C, RNA.C, RNA.G)
+                }
+            },
+            {
+                AA.TRP, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.G, RNA.G)
+                }
+            },
+            {
+                AA.TYR, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.A, RNA.U),
+                    new Codon(RNA.U, RNA.A, RNA.C)
+                }
+            },
+            {
+                AA.VAL, new List<Codon>()
+                {
+                    new Codon(RNA.G, RNA.U, RNA.U),
+                    new Codon(RNA.G, RNA.U, RNA.C),
+                    new Codon(RNA.G, RNA.U, RNA.A),
+                    new Codon(RNA.G, RNA.U, RNA.G)
+                }
+            },
+            {
+                AA.ILE, new List<Codon>()
+                {
+                    new Codon(RNA.A, RNA.U, RNA.U),
+                    new Codon(RNA.A, RNA.U, RNA.C),
+                    new Codon(RNA.A, RNA.U, RNA.A)
+                }
+            },
+            {
+                AA.STOP, new List<Codon>()
+                {
+                    new Codon(RNA.U, RNA.A, RNA.A),
+                    new Codon(RNA.U, RNA.A, RNA.G),
+                    new Codon(RNA.U, RNA.G, RNA.A)
+                }
+            }
+
+        };
+
+        public static Dictionary<AA, List<Codon>> Dic
+        {
+            get
+            {
+                return _dic;
+            }
+        }
+
+
         /// <summary>
         /// Given a Character representing a RNA Base, the function will return the matching RNA Base
         /// 'A' -> RNA.A
         /// </summary>
         /// <param name="b">Character representing a RNA Base</param>
         /// <returns>RNA Base</returns>
-        public static RNA  matchRnaB(char b)
+        public static RNA MatchRnaB(char b)
         {
-            switch(b)
+            switch (b)
             {
                 case 'A':
                     return RNA.A;
@@ -37,7 +220,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">RNA Base</param>
         /// <returns>Character Representing a RNA Base</returns>
-        public static char matchRnaB(RNA b)
+        public static char MatchRnaB(RNA b)
         {
             switch (b)
             {
@@ -60,7 +243,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">Character Representing a RNA Base</param>
         /// <returns>RNA Base</returns>
-        public static RNA matchOpositeRnaB(char b)
+        public static RNA MatchOpositeRnaB(char b)
         {
             switch (b)
             {
@@ -83,7 +266,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">RNA Base</param>
         /// <returns>Character Representing a RNA Base</returns>
-        public static char matchOpositeRnaB(RNA b)
+        public static char MatchOpositeRnaB(RNA b)
         {
             switch (b)
             {
@@ -106,17 +289,17 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">Character representing a DNA Base</param>
         /// <returns>DNA Base</returns>
-        public static DNA matchDnaB(char b)
+        public static DNA MatchDnaB(char b)
         {
             switch (b)
             {
                 case 'A':
                     return DNA.A;
-                case 'C':  
+                case 'C':
                     return DNA.C;
-                case 'T':  
+                case 'T':
                     return DNA.T;
-                case 'G':  
+                case 'G':
                     return DNA.G;
                 default:
                     throw new NotImplementedException();
@@ -129,7 +312,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">DNA Base</param>
         /// <returns>Character Representing a DNA Base</returns>
-        public static char matchDnaB(DNA b)
+        public static char MatchDnaB(DNA b)
         {
             switch (b)
             {
@@ -153,7 +336,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">Character Representing a DNA Base</param>
         /// <returns>RNA Base</returns>
-        public static DNA matchOpositeDnaB(char b)
+        public static DNA MatchOpositeDnaB(char b)
         {
             switch (b)
             {
@@ -176,7 +359,7 @@ namespace DRPTranslatorCS
         /// </summary>
         /// <param name="b">DNA Base</param>
         /// <returns>Character Representing a DNA Base</returns>
-        public static char matchOpositeDnaB(DNA b)
+        public static char MatchOpositeDnaB(DNA b)
         {
             switch (b)
             {
@@ -194,454 +377,64 @@ namespace DRPTranslatorCS
         }
 
         /// <summary>
-        /// Given an aminoacid, the function will return it's matching codon representing string
-        /// AA.ALA -> "ALA"
-        /// </summary>
-        /// <param name="amino">Aminoacid to match</param>
-        /// <returns>String representing an aminoacid</returns>
-        public static string matchAAStr(AA amino)
-        {
-            string aa = "";
-            switch (amino)
-            {
-                case AA.ALA:
-                    aa = "ALA";
-                    break;
-                case AA.ARG:
-                    aa = "ARG";
-                    break;
-                case AA.ASN:
-                    aa = "ASN";
-                    break;
-                case AA.ASP:
-                    aa = "ASP";
-                    break;
-                case AA.CYS:
-                    aa = "CYS";
-                    break;
-                case AA.GLN:
-                    aa = "GLN";
-                    break;
-                case AA.GLU:
-                    aa = "GLU";
-                    break;
-                case AA.GLY:
-                    aa = "GLY";
-                    break;
-                case AA.HIS:
-                    aa = "HIS";
-                    break;
-                case AA.LEU:
-                    aa = "LEU";
-                    break;
-                case AA.LYS:
-                    aa = "LYS";
-                    break;
-                case AA.MET:
-                    aa = "MET";
-                    break;
-                case AA.PHE:
-                    aa = "PHE";
-                    break;
-                case AA.PRO:
-                    aa = "PRO";
-                    break;
-                case AA.SER:
-                    aa = "SER";
-                    break;
-                case AA.THR:
-                    aa = "THR";
-                    break;
-                case AA.TRP:
-                    aa = "TRP";
-                    break;
-                case AA.TYR:
-                    aa = "TYR";
-                    break;
-                case AA.VAL:
-                    aa = "VAL";
-                    break;
-                case AA.ILE:
-                    aa = "ILE";
-                    break;
-                case AA.STOP:
-                    aa = "STOP";
-                    break;
-                default:
-                    throw new ArgumentException();
-            }
-            return aa;
-        }
-
-        /// <summary>
         /// Given a string representing an aminoacid, the function will return it's matching aminoacid enum
         /// "ALA" -> AA.ALA
         /// </summary>
         /// <param name="codon"></param>
         /// <returns></returns>
-        public static AA matchStrAA(string amino)
+        public static AA MatchStrAA(string amino)
         {
-            AA aa;
-            switch (amino)
+            AA key = 0;
+            foreach (var index in Dic)
             {
-                case "ALA":
-                    aa = AA.ALA;
-                    break;
-                case "ARG":
-                    aa = AA.ARG;
-                    break;
-                case "ASN":
-                    aa = AA.ASN;
-                    break;
-                case "ASP":
-                    aa = AA.ASP;
-                    break;
-                case "CYS":
-                    aa = AA.CYS;
-                    break;
-                case "GLN":
-                    aa = AA.GLN;
-                    break;
-                case "GLU":
-                    aa = AA.GLU;
-                    break;
-                case "GLY":
-                    aa = AA.GLY;
-                    break;
-                case "HIS":
-                    aa = AA.HIS;
-                    break;
-                case "LEU":
-                    aa = AA.LEU;
-                    break;
-                case "LYS":
-                    aa = AA.LYS;
-                    break;
-                case "MET":
-                    aa = AA.MET;
-                    break;
-                case "PHE":
-                    aa = AA.PHE;
-                    break;
-                case "PRO":
-                    aa = AA.PRO;
-                    break;
-                case "SER":
-                    aa = AA.SER;
-                    break;
-                case "THR":
-                    aa = AA.THR;
-                    break;
-                case "TRP":
-                    aa = AA.TRP;
-                    break;
-                case "TYR":
-                    aa = AA.TYR;
-                    break;
-                case "VAL":
-                    aa = AA.VAL;
-                    break;
-                case "ILE":
-                    aa = AA.ILE;
-                    break;
-                case "STOP":
-                    aa = AA.STOP;
-                    break;
-                default:
-                    throw new ArgumentException();
+                if (index.Key.ToString() == amino)
+                {
+                    key = index.Key;
+                }
             }
-            return aa;
-        }
-        /// <summary>
-        /// Given an aminoacid, the function will make a dictionary in which will include
-        /// the Aminoacid and  a list containing all the possible dna codons that can form it.
-        /// </summary>
-        /// <param name="amino"></param>
-        /// <returns></returns>
-        public static Dictionary<AA, List<DnaCodon>> matchAminoDna(AA amino)
-        {
-            Dictionary<AA, List<DnaCodon>> aminoDic = new Dictionary<AA, List<DnaCodon>>();
-            List<DnaCodon> codList = new List<DnaCodon>();
-            switch (amino)
+            if (key.ToString() != amino)
             {
-                case AA.ALA: // 4 CODONS
-                    codList.Add(new DnaCodon(DNA.G, DNA.C, DNA.T));
-                    codList.Add(new DnaCodon(DNA.G, DNA.C, DNA.C));
-                    codList.Add(new DnaCodon(DNA.G, DNA.C, DNA.A));
-                    codList.Add(new DnaCodon(DNA.G, DNA.C, DNA.G));
-                    aminoDic.Add(AA.ALA, codList);
-                    break;
-                case AA.ARG: // 6 CODONS
-                    codList.Add(new DnaCodon(DNA.C, DNA.G, DNA.T));
-                    codList.Add(new DnaCodon(DNA.C, DNA.G, DNA.C));
-                    codList.Add(new DnaCodon(DNA.C, DNA.G, DNA.A));
-                    codList.Add(new DnaCodon(DNA.C, DNA.G, DNA.G));
-                    codList.Add(new DnaCodon(DNA.A, DNA.G, DNA.A));
-                    codList.Add(new DnaCodon(DNA.A, DNA.G, DNA.G));
-                    aminoDic.Add(AA.ARG, codList);
-                    break;
-                case AA.ASN: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.A, DNA.A, DNA.T));
-                    codList.Add(new DnaCodon(DNA.A, DNA.A, DNA.C));
-                    aminoDic.Add(AA.ASN, codList);
-                    break;
-                case AA.ASP: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.G, DNA.A, DNA.T));
-                    codList.Add(new DnaCodon(DNA.G, DNA.A, DNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.CYS: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.T));
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.GLN: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.T));
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.GLU: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.G, DNA.A, DNA.A));
-                    codList.Add(new DnaCodon(DNA.G, DNA.A, DNA.G));
-                    aminoDic.Add(AA.GLU, codList);
-                    break;
-                case AA.GLY: // 4 CODONS
-                    codList.Add(new DnaCodon(DNA.G, DNA.G, DNA.T));
-                    codList.Add(new DnaCodon(DNA.G, DNA.G, DNA.C));
-                    codList.Add(new DnaCodon(DNA.G, DNA.G, DNA.A));
-                    codList.Add(new DnaCodon(DNA.G, DNA.G, DNA.G));
-                    aminoDic.Add(AA.GLY, codList);
-                    break;
-                case AA.HIS: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.C, DNA.A, DNA.T));
-                    codList.Add(new DnaCodon(DNA.C, DNA.A, DNA.C));
-                    aminoDic.Add(AA.HIS, codList);
-                    break;
-                case AA.LEU: // 6 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.T, DNA.A));
-                    codList.Add(new DnaCodon(DNA.T, DNA.T, DNA.G));
-                    codList.Add(new DnaCodon(DNA.C, DNA.T, DNA.T));
-                    codList.Add(new DnaCodon(DNA.C, DNA.T, DNA.C));
-                    codList.Add(new DnaCodon(DNA.C, DNA.T, DNA.A));
-                    codList.Add(new DnaCodon(DNA.C, DNA.T, DNA.G));
-                    aminoDic.Add(AA.LEU, codList);
-                    break;
-                case AA.LYS: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.A, DNA.A, DNA.A));
-                    codList.Add(new DnaCodon(DNA.A, DNA.A, DNA.G));
-                    aminoDic.Add(AA.LYS, codList);
-                    break;
-                case AA.MET: //  1 CODON
-                    codList.Add(new DnaCodon(DNA.A, DNA.T, DNA.G));
-                    aminoDic.Add(AA.MET, codList);
-                    break;
-                case AA.PHE: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.T, DNA.T));
-                    codList.Add(new DnaCodon(DNA.T, DNA.T, DNA.C));
-                    aminoDic.Add(AA.PHE, codList);
-                    break;
-                case AA.PRO: // 4 CODONS
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.T));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.C));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.A));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.G));
-                    aminoDic.Add(AA.PRO, codList);
-                    break;
-                case AA.SER: // 6 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.C, DNA.T));
-                    codList.Add(new DnaCodon(DNA.T, DNA.C, DNA.C));
-                    codList.Add(new DnaCodon(DNA.T, DNA.C, DNA.A));
-                    codList.Add(new DnaCodon(DNA.T, DNA.C, DNA.G));
-                    codList.Add(new DnaCodon(DNA.A, DNA.G, DNA.T));
-                    codList.Add(new DnaCodon(DNA.A, DNA.G, DNA.C));
-                    aminoDic.Add(AA.SER, codList);
-                    break;
-                case AA.THR: // 4 CODONS
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.T));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.C));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.A));
-                    codList.Add(new DnaCodon(DNA.C, DNA.C, DNA.G));
-                    aminoDic.Add(AA.PRO, codList);
-                    break;
-                case AA.TRP: // 1 CODON
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.G));
-                    aminoDic.Add(AA.TRP, codList);
-                    break;
-                case AA.TYR: // 2 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.A, DNA.T));
-                    codList.Add(new DnaCodon(DNA.T, DNA.A, DNA.C));
-                    aminoDic.Add(AA.TYR, codList);
-                    break;
-                case AA.VAL: // 4 CODONS
-                    codList.Add(new DnaCodon(DNA.G, DNA.T, DNA.T));
-                    codList.Add(new DnaCodon(DNA.G, DNA.T, DNA.C));
-                    codList.Add(new DnaCodon(DNA.G, DNA.T, DNA.A));
-                    codList.Add(new DnaCodon(DNA.G, DNA.T, DNA.G));
-                    aminoDic.Add(AA.VAL, codList);
-                    break;
-                case AA.ILE: // 3 CODONS
-                    codList.Add(new DnaCodon(DNA.A, DNA.T, DNA.T));
-                    codList.Add(new DnaCodon(DNA.A, DNA.T, DNA.C));
-                    codList.Add(new DnaCodon(DNA.A, DNA.T, DNA.A));
-                    aminoDic.Add(AA.ILE, codList);
-                    break;
-                case AA.STOP: // 3 CODONS
-                    codList.Add(new DnaCodon(DNA.T, DNA.A, DNA.A));
-                    codList.Add(new DnaCodon(DNA.T, DNA.A, DNA.G));
-                    codList.Add(new DnaCodon(DNA.T, DNA.G, DNA.A));
-                    aminoDic.Add(AA.STOP, codList);
-                    break;
-                default:
-                    throw new ArgumentException();
+                throw new KeyNotFoundException();
             }
-            return aminoDic;
+            else
+            {
+                return key;
+            }
         }
 
         /// <summary>
-        /// Given an aminoacid, the function will make a dictionary in which will include
-        /// the Aminoacid and  a list containing all the possible RNA codons that can form it.
+        /// 
+        /// </summary>
+        /// <param name="codons"></param>
+        /// <returns></returns>
+        public static List<AA> MatchAACod(List<Codon> codons)
+        {
+            List<AA> aaList = new List<AA>();
+            foreach (Codon codon in codons)
+            {
+                aaList.Add(MatchAACod(codon));
+            }
+            return aaList;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="codon"></param>
+        /// <returns></returns>
+        public static AA MatchAACod(Codon codon)
+        {
+            return MatchStrAA(codon.ToString());
+        }
+
+        /// <summary>
+        /// 
         /// </summary>
         /// <param name="amino"></param>
         /// <returns></returns>
-        public static Dictionary<AA,List<RnaCodon>> matchAminoRna(AA amino)
+        public static List<Codon> MatchCodonAA(AA amino)
         {
-            Dictionary<AA, List<RnaCodon>> aminoDic = new Dictionary<AA, List<RnaCodon>>();
-            List<RnaCodon> codList = new List<RnaCodon>();
-            switch (amino)
-            {
-                case AA.ALA: // 4 CODONS
-                    codList.Add(new RnaCodon(RNA.G, RNA.C, RNA.U));
-                    codList.Add(new RnaCodon(RNA.G, RNA.C, RNA.C));
-                    codList.Add(new RnaCodon(RNA.G, RNA.C, RNA.A));
-                    codList.Add(new RnaCodon(RNA.G, RNA.C, RNA.G));
-                    aminoDic.Add(AA.ALA, codList);
-                    break;
-                case AA.ARG: // 6 CODONS
-                    codList.Add(new RnaCodon(RNA.C, RNA.G, RNA.U));
-                    codList.Add(new RnaCodon(RNA.C, RNA.G, RNA.C));
-                    codList.Add(new RnaCodon(RNA.C, RNA.G, RNA.A));
-                    codList.Add(new RnaCodon(RNA.C, RNA.G, RNA.G));
-                    codList.Add(new RnaCodon(RNA.A, RNA.G, RNA.A));
-                    codList.Add(new RnaCodon(RNA.A, RNA.G, RNA.G));
-                    aminoDic.Add(AA.ARG, codList);
-                    break;
-                case AA.ASN: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.A, RNA.A, RNA.U));
-                    codList.Add(new RnaCodon(RNA.A, RNA.A, RNA.C));
-                    aminoDic.Add(AA.ASN, codList);
-                    break;
-                case AA.ASP: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.G, RNA.A, RNA.U));
-                    codList.Add(new RnaCodon(RNA.G, RNA.A, RNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.CYS: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.U));
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.GLN: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.U));
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.C));
-                    aminoDic.Add(AA.ASP, codList);
-                    break;
-                case AA.GLU: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.G, RNA.A, RNA.A));
-                    codList.Add(new RnaCodon(RNA.G, RNA.A, RNA.G));
-                    aminoDic.Add(AA.GLU, codList);
-                    break;
-                case AA.GLY: // 4 CODONS
-                    codList.Add(new RnaCodon(RNA.G, RNA.G, RNA.U));
-                    codList.Add(new RnaCodon(RNA.G, RNA.G, RNA.C));
-                    codList.Add(new RnaCodon(RNA.G, RNA.G, RNA.A));
-                    codList.Add(new RnaCodon(RNA.G, RNA.G, RNA.G));
-                    aminoDic.Add(AA.GLY, codList);
-                    break;
-                case AA.HIS: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.C, RNA.A, RNA.U));
-                    codList.Add(new RnaCodon(RNA.C, RNA.A, RNA.C));
-                    aminoDic.Add(AA.HIS, codList);
-                    break;
-                case AA.LEU: // 6 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.U, RNA.A));
-                    codList.Add(new RnaCodon(RNA.U, RNA.U, RNA.G));
-                    codList.Add(new RnaCodon(RNA.C, RNA.U, RNA.U));
-                    codList.Add(new RnaCodon(RNA.C, RNA.U, RNA.C));
-                    codList.Add(new RnaCodon(RNA.C, RNA.U, RNA.A));
-                    codList.Add(new RnaCodon(RNA.C, RNA.U, RNA.G));
-                    aminoDic.Add(AA.LEU, codList);
-                    break;
-                case AA.LYS: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.A, RNA.A, RNA.A));
-                    codList.Add(new RnaCodon(RNA.A, RNA.A, RNA.G));
-                    aminoDic.Add(AA.LYS, codList);
-                    break;
-                case AA.MET: //  1 CODON
-                    codList.Add(new RnaCodon(RNA.A, RNA.U, RNA.G));
-                    aminoDic.Add(AA.MET, codList);
-                    break;
-                case AA.PHE: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.U, RNA.U));
-                    codList.Add(new RnaCodon(RNA.U, RNA.U, RNA.C));
-                    aminoDic.Add(AA.PHE, codList);
-                    break;
-                case AA.PRO: // 4 CODONS
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.U));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.C));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.A));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.G));
-                    aminoDic.Add(AA.PRO, codList);
-                    break;
-                case AA.SER: // 6 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.C, RNA.U));
-                    codList.Add(new RnaCodon(RNA.U, RNA.C, RNA.C));
-                    codList.Add(new RnaCodon(RNA.U, RNA.C, RNA.A));
-                    codList.Add(new RnaCodon(RNA.U, RNA.C, RNA.G));
-                    codList.Add(new RnaCodon(RNA.A, RNA.G, RNA.U));
-                    codList.Add(new RnaCodon(RNA.A, RNA.G, RNA.C));
-                    aminoDic.Add(AA.SER, codList);
-                    break;
-                case AA.THR: // 4 CODONS
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.U));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.C));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.A));
-                    codList.Add(new RnaCodon(RNA.C, RNA.C, RNA.G));
-                    aminoDic.Add(AA.PRO, codList);
-                    break;
-                case AA.TRP: // 1 CODON
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.G));
-                    aminoDic.Add(AA.TRP, codList);
-                    break;
-                case AA.TYR: // 2 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.A, RNA.U));
-                    codList.Add(new RnaCodon(RNA.U, RNA.A, RNA.C));
-                    aminoDic.Add(AA.TYR, codList);
-                    break;
-                case AA.VAL: // 4 CODONS
-                    codList.Add(new RnaCodon(RNA.G, RNA.U, RNA.U));
-                    codList.Add(new RnaCodon(RNA.G, RNA.U, RNA.C));
-                    codList.Add(new RnaCodon(RNA.G, RNA.U, RNA.A));
-                    codList.Add(new RnaCodon(RNA.G, RNA.U, RNA.G));
-                    aminoDic.Add(AA.VAL, codList);
-                    break;
-                case AA.ILE: // 3 CODONS
-                    codList.Add(new RnaCodon(RNA.A, RNA.U, RNA.U));
-                    codList.Add(new RnaCodon(RNA.A, RNA.U, RNA.C));
-                    codList.Add(new RnaCodon(RNA.A, RNA.U, RNA.A));
-                    aminoDic.Add(AA.ILE, codList);
-                    break;
-                case AA.STOP: // 3 CODONS
-                    codList.Add(new RnaCodon(RNA.U, RNA.A, RNA.A));
-                    codList.Add(new RnaCodon(RNA.U, RNA.A, RNA.G));
-                    codList.Add(new RnaCodon(RNA.U, RNA.G, RNA.A));
-                    aminoDic.Add(AA.STOP, codList);
-                    break;
-                default:
-                    throw new ArgumentException();
-            }
-            return aminoDic;
+            return Dic[amino];
         }
-
-
     }
 }

--- a/src/Sequence.cs
+++ b/src/Sequence.cs
@@ -11,8 +11,8 @@ namespace DRPTranslatorCS
         string _compSeq;
         string _aaSeq;
 
-        List<RnaCodon> _rnaCodons;
-        List<DnaCodon> _dnaCodons;
+        List<Codon> _codons;
+        
 
         Dictionary<int, string> _starts;
         Dictionary<int, string> _stops;

--- a/src/symbols/Codon.cs
+++ b/src/symbols/Codon.cs
@@ -5,935 +5,30 @@ using System.Text.RegularExpressions;
 
 namespace DRPTranslatorCS.Symbols
 {
-    /// <summary>
-    /// Struct that Holds methods which transform strings into Codon Lists or Codon Lists into Strings
-    /// </summary>
-    public struct Codon
+    public class Codon
     {
+        private RNA fp;
+        private RNA sp;
+        private RNA tp;
 
-        /// <summary>
-        /// Given a DNA sequence that it's length must be divisible by 3,
-        /// the function will return a List of DNA Codons
-        /// </summary>
-        /// <param name="dnaSeq">DNA sequence string, it's length must be divisible by 3</param>
-        /// <returns>A List of DnaCodon Structs</returns>
-        public static List<DnaCodon> getDnaCodonList(string dnaSeq)
+        public Codon() { }
+        public Codon(RNA fp, RNA sp, RNA tp)
         {
-            if (dnaSeq.Length % 3 != 0)
-                throw new IndexOutOfRangeException();
-
-            List<string> strCodons = (from Match m in Regex.Matches(dnaSeq, @"\.{3}") select m.Value).ToList();
-            List<DnaCodon> dnaCodons = new List<DnaCodon>();
-            foreach (string strCodon in strCodons)
-            {
-                DNA fp = GeneticMatcher.matchDnaB(strCodon[0]);
-                DNA sp = GeneticMatcher.matchDnaB(strCodon[1]);
-                DNA tp = GeneticMatcher.matchDnaB(strCodon[2]);
-                dnaCodons.Add(new DnaCodon(fp, sp, tp));
-            }
-            return dnaCodons;
-        }
-
-        /// <summary>
-        /// Given a RNA sequence that it's length must be divisible by 3,
-        /// the function will return a List of RNA Codons
-        /// </summary>
-        /// <param name="rnaSeq">RNA sequence string, it's length must be divisible by 3</param>
-        /// <returns>A List of RnaCodon Structs</returns>
-        public static List<RnaCodon> getRnaCodonList(string rnaSeq)
-        {
-            if (rnaSeq.Length % 3 != 0)
-                throw new IndexOutOfRangeException();
-
-            List<string> strCodons = (from Match m in Regex.Matches(rnaSeq, @"\.{3}") select m.Value).ToList();
-            List<RnaCodon> rnaCodons = new List<RnaCodon>();
-            foreach (string strCodon in strCodons)
-            {
-                RNA fp = GeneticMatcher.matchRnaB(strCodon[0]);
-                RNA sp = GeneticMatcher.matchRnaB(strCodon[1]);
-                RNA tp = GeneticMatcher.matchRnaB(strCodon[2]);
-                rnaCodons.Add(new RnaCodon(fp, sp, tp));
-            }
-            return rnaCodons;
-        }
-
-        /// <summary>
-        /// Given a DnaCodon List, the function will concatenate all codons
-        /// into a single string sequence of aminoacids
-        /// ATCACT -> "MET-STOP"
-        /// </summary>
-        /// <param name="codons">List of DnaCodons</param>
-        /// <returns>String containing an Aminoacid sequence</returns>
-        public static string getDnaCodonSeqStr(List<DnaCodon> codons)
-        {
-            string codSeq = "";
-            foreach (DnaCodon codon in codons)
-            {
-                if (codons.IndexOf(codon) == codons.Count - 1)
-                {
-                    codSeq += getDnaCodonStr(codon);
-                }
-                else
-                {
-                    codSeq += getDnaCodonStr(codon) + "-";
-                }
-            }
-            return codSeq;
-        }
-        //TODO:Implement the usage of AA Enum, say having a DnaCodon || RnaCodon list, return a list of aminoacids
-
-        /// <summary>
-        /// Given a DnaCodon, the function will match the codon's genetic bases
-        /// to it's aminoacid counterpart
-        /// ATC -> MET
-        /// </summary>
-        /// <param name="codon">DnaCodon</param>
-        /// <returns>String that represents the DNA Codon</returns>
-        //TODO: Change all NotImplementedException
-        public static string getDnaCodonStr(DnaCodon codon)
-        {
-            string aa = "";
-            switch (codon.Fp)
-            {
-                case DNA.A:
-                    switch (codon.Sp)
-                    {
-                        case DNA.A:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // AAA
-                                    aa = "LYS";
-                                    break;
-                                case DNA.T: // AAT
-                                    aa = "ASN";
-                                    break;
-                                case DNA.G: // AAG
-                                    aa = "LYS";
-                                    break;
-                                case DNA.C: // AAC
-                                    aa = "ASN";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.T:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // ATA
-                                    aa = "ILE";
-                                    break;
-                                case DNA.T: // ATT
-                                    aa = "ILE";
-                                    break;
-                                case DNA.G: // ATG
-                                    aa = "MET";
-                                    break;
-                                case DNA.C: // ATC
-                                    aa = "ILE";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.G:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // AGA
-                                    aa = "ARG";
-                                    break;
-                                case DNA.T: // AGT
-                                    aa = "SER";
-                                    break;
-                                case DNA.G: // AGG
-                                    aa = "ARG";
-                                    break;
-                                case DNA.C: // AGC
-                                    aa = "SER";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.C:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // ACA
-                                    aa = "THR";
-                                    break;
-                                case DNA.T: // ACT
-                                    aa = "THR";
-                                    break;
-                                case DNA.G: // ACG
-                                    aa = "THR";
-                                    break;
-                                case DNA.C: // ACC
-                                    aa = "THR";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case DNA.T:
-                    switch (codon.Sp)
-                    {
-                        case DNA.A:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // TAA
-                                    aa = "STOP";
-                                    break;
-                                case DNA.T: // TAT
-                                    aa = "TYR";
-                                    break;
-                                case DNA.G: // TAG
-                                    aa = "STOP";
-                                    break;
-                                case DNA.C: // TAC
-                                    aa = "TYR";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.T:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // TTA
-                                    aa = "LEU";
-                                    break;
-                                case DNA.T: // TTT
-                                    aa = "PHE";
-                                    break;
-                                case DNA.G: // TTG
-                                    aa = "LEU";
-                                    break;
-                                case DNA.C: // TTC
-                                    aa = "PHE";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.G:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // TGA
-                                    aa = "STOP";
-                                    break;
-                                case DNA.T: // TGT
-                                    aa = "CYS";
-                                    break;
-                                case DNA.G: // TGG
-                                    aa = "Trp";
-                                    break;
-                                case DNA.C: // TGC
-                                    aa = "CYS";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.C:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // TCA
-                                    aa = "SER";
-                                    break;
-                                case DNA.T: // TCT
-                                    aa = "SER";
-                                    break;
-                                case DNA.G: // TCG
-                                    aa = "SER";
-                                    break;
-                                case DNA.C: // TCC
-                                    aa = "SER";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case DNA.G:
-                    switch (codon.Sp)
-                    {
-                        case DNA.A:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // GAA
-                                    aa = "GLU";
-                                    break;
-                                case DNA.T: // GAT
-                                    aa = "ASP";
-                                    break;
-                                case DNA.G: // GAG
-                                    aa = "GLU";
-                                    break;
-                                case DNA.C: // GAC
-                                    aa = "ASP";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.T:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // GTA
-                                    aa = "VAL";
-                                    break;
-                                case DNA.T: // GTT
-                                    aa = "VAL";
-                                    break;
-                                case DNA.G: // GTG
-                                    aa = "VAL";
-                                    break;
-                                case DNA.C: // GTC
-                                    aa = "VAL";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.G:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // GGA
-                                    aa = "GLY";
-                                    break;
-                                case DNA.T: // GGT
-                                    aa = "GLY";
-                                    break;
-                                case DNA.G: // GGG
-                                    aa = "GLY";
-                                    break;
-                                case DNA.C: // GGC
-                                    aa = "GLY";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.C:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // GCA
-                                    aa = "ALA";
-                                    break;
-                                case DNA.T: // GCT
-                                    aa = "ALA";
-                                    break;
-                                case DNA.G: // GCG
-                                    aa = "ALA";
-                                    break;
-                                case DNA.C: // GCC
-                                    aa = "ALA";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case DNA.C:
-                    switch (codon.Sp)
-                    {
-                        case DNA.A:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // CAA
-                                    aa = "GLN";
-                                    break;
-                                case DNA.T: // CAT
-                                    aa = "HIS";
-                                    break;
-                                case DNA.G: // CAG
-                                    aa = "GLN";
-                                    break;
-                                case DNA.C: // CAC
-                                    aa = "HIS";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.T:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // CTA
-                                    aa = "LEU";
-                                    break;
-                                case DNA.T: // CTT
-                                    aa = "LEU";
-                                    break;
-                                case DNA.G: // CTG
-                                    aa = "LEU";
-                                    break;
-                                case DNA.C: // CTC
-                                    aa = "LEU";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.G:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // CGA
-                                    aa = "ARG";
-                                    break;
-                                case DNA.T: // CGT
-                                    aa = "ARG";
-                                    break;
-                                case DNA.G: // CGG
-                                    aa = "ARG";
-                                    break;
-                                case DNA.C: // CGC
-                                    aa = "ARG";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case DNA.C:
-                            switch (codon.Tp)
-                            {
-                                case DNA.A: // CCA
-                                    aa = "PRO";
-                                    break;
-                                case DNA.T: // CCT
-                                    aa = "PRO";
-                                    break;
-                                case DNA.G: // CCG
-                                    aa = "PRO";
-                                    break;
-                                case DNA.C: // CCC
-                                    aa = "PRO";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                default:
-                    throw new System.NotImplementedException();
-            }//first level
-            return aa;
-        }
-
-        /// <summary>
-        /// Given a DNA Codon string, the function will return a new DnaCodon
-        /// "ATG" -> MET
-        /// </summary>
-        /// <param name="codon">String representing a DNA Codon</param>
-        /// <returns>DNA Codon</returns>
-        public static DnaCodon getDnaCodon(string codon)
-        {
-            char[] charArr = codon.ToCharArray();
-            List<DNA> rnaList = new List<DNA>();
-            foreach (char b in charArr)
-            {
-                rnaList.Add(GeneticMatcher.matchDnaB(b));
-            }
-            return new DnaCodon(rnaList[0], rnaList[1], rnaList[2]);
-        }
-
-        /// <summary>
-        /// Given a RnaCodon List, the function will concatenate all codons
-        /// into a single string sequence of aminoacids
-        /// AUGUAG -> "MET-STOP"
-        /// </summary>
-        /// <param name="codons">List of RnaCodons</param>
-        /// <returns>String containing an Aminoacid sequence</returns>
-        public static string getRnaCodonSeqStr(List<RnaCodon> codons)
-        {
-            string codSeq = "";
-            foreach (RnaCodon codon in codons)
-            {
-                if (codons.IndexOf(codon) == codons.Count - 1)
-                {
-                    codSeq += getRnaCodonStr(codon);
-                }
-                else
-                {
-                    codSeq += getRnaCodonStr(codon) + "-";
-                }
-            }
-            return codSeq;
-        }
-
-        /// <summary>
-        /// Given a RnaCodon, the function will match the codon's genetic bases
-        /// to it's aminoacid counterpart
-        /// AUG -> MET
-        /// </summary>
-        /// <param name="codon">RnaCodon</param>
-        /// <returns>String that represents the DNA Codon</returns>
-        //TODO: Change all NotImplementedExceptions
-        public static string getRnaCodonStr(RnaCodon codon)
-        {
-            string aa = "";
-            switch (codon.Fp)
-            {
-                case RNA.A:
-                    switch (codon.Sp)
-                    {
-                        case RNA.A:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // AAA
-                                    aa = "LYS";
-                                    break;
-                                case RNA.U: // AAU
-                                    aa = "ASN";
-                                    break;
-                                case RNA.G: // AAG
-                                    aa = "LYS";
-                                    break;
-                                case RNA.C: // AAC
-                                    aa = "ASN";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.U:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // AUA
-                                    aa = "ILE";
-                                    break;
-                                case RNA.U: // AUU
-                                    aa = "ILE";
-                                    break;
-                                case RNA.G: // AUG
-                                    aa = "MET";
-                                    break;
-                                case RNA.C: // AUC
-                                    aa = "ILE";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.G:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // AGA
-                                    aa = "ARG";
-                                    break;
-                                case RNA.U: // AGU
-                                    aa = "SER";
-                                    break;
-                                case RNA.G: // AGG
-                                    aa = "ARG";
-                                    break;
-                                case RNA.C: // AGC
-                                    aa = "SER";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.C:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // ACA
-                                    aa = "THR";
-                                    break;
-                                case RNA.U: // ACU
-                                    aa = "THR";
-                                    break;
-                                case RNA.G: // ACG
-                                    aa = "THR";
-                                    break;
-                                case RNA.C: // ACC
-                                    aa = "THR";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case RNA.U:
-                    switch (codon.Sp)
-                    {
-                        case RNA.A:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // UAA
-                                    aa = "STOP";
-                                    break;
-                                case RNA.U: // UAU
-                                    aa = "TYR";
-                                    break;
-                                case RNA.G: // UAG
-                                    aa = "STOP";
-                                    break;
-                                case RNA.C: // UAC
-                                    aa = "TYR";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.U:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // UUA
-                                    aa = "LEU";
-                                    break;
-                                case RNA.U: // UUU
-                                    aa = "PHE";
-                                    break;
-                                case RNA.G: // UUG
-                                    aa = "LEU";
-                                    break;
-                                case RNA.C: // UUC
-                                    aa = "PHE";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.G:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // UGA
-                                    aa = "STOP";
-                                    break;
-                                case RNA.U: // UGU
-                                    aa = "CYS";
-                                    break;
-                                case RNA.G: // UGG
-                                    aa = "Trp";
-                                    break;
-                                case RNA.C: // UGC
-                                    aa = "CYS";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.C:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // UCA
-                                    aa = "SER";
-                                    break;
-                                case RNA.U: // UCU
-                                    aa = "SER";
-                                    break;
-                                case RNA.G: // UCG
-                                    aa = "SER";
-                                    break;
-                                case RNA.C: // UCC
-                                    aa = "SER";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case RNA.G:
-                    switch (codon.Sp)
-                    {
-                        case RNA.A:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // GAA
-                                    aa = "GLU";
-                                    break;
-                                case RNA.U: // GAU
-                                    aa = "ASP";
-                                    break;
-                                case RNA.G: // GAG
-                                    aa = "GLU";
-                                    break;
-                                case RNA.C: // GAC
-                                    aa = "ASP";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.U:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // GUA
-                                    aa = "VAL";
-                                    break;
-                                case RNA.U: // GUU
-                                    aa = "VAL";
-                                    break;
-                                case RNA.G: // GUG
-                                    aa = "VAL";
-                                    break;
-                                case RNA.C: // GUC
-                                    aa = "VAL";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.G:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // GGA
-                                    aa = "GLY";
-                                    break;
-                                case RNA.U: // GGU
-                                    aa = "GLY";
-                                    break;
-                                case RNA.G: // GGG
-                                    aa = "GLY";
-                                    break;
-                                case RNA.C: // GGC
-                                    aa = "GLY";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.C:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // GCA
-                                    aa = "ALA";
-                                    break;
-                                case RNA.U: // GCU
-                                    aa = "ALA";
-                                    break;
-                                case RNA.G: // GCG
-                                    aa = "ALA";
-                                    break;
-                                case RNA.C: // GCC
-                                    aa = "ALA";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                case RNA.C:
-                    switch (codon.Sp)
-                    {
-                        case RNA.A:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // CAA
-                                    aa = "GLN";
-                                    break;
-                                case RNA.U: // CAU
-                                    aa = "HIS";
-                                    break;
-                                case RNA.G: // CAG
-                                    aa = "GLN";
-                                    break;
-                                case RNA.C: // CAC
-                                    aa = "HIS";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.U:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // CUA
-                                    aa = "LEU";
-                                    break;
-                                case RNA.U: // CUU
-                                    aa = "LEU";
-                                    break;
-                                case RNA.G: // CUG
-                                    aa = "LEU";
-                                    break;
-                                case RNA.C: // CUC
-                                    aa = "LEU";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.G:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // CGA
-                                    aa = "ARG";
-                                    break;
-                                case RNA.U: // CGU
-                                    aa = "ARG";
-                                    break;
-                                case RNA.G: // CGG
-                                    aa = "ARG";
-                                    break;
-                                case RNA.C: // CGC
-                                    aa = "ARG";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        case RNA.C:
-                            switch (codon.Tp)
-                            {
-                                case RNA.A: // CCA
-                                    aa = "PRO";
-                                    break;
-                                case RNA.U: // CCU
-                                    aa = "PRO";
-                                    break;
-                                case RNA.G: // CCG
-                                    aa = "PRO";
-                                    break;
-                                case RNA.C: // CCC
-                                    aa = "PRO";
-                                    break;
-                                default:
-                                    throw new System.NotImplementedException();
-                            }//third level
-                            break;
-                        default:
-                            throw new System.NotImplementedException();
-                    }//second level
-                    break;
-                default:
-                    throw new System.NotImplementedException();
-            }//first level
-            return aa;
-        }
-
-        /// <summary>
-        /// Given a RNA Codon string, the function will return a new DnaCodon
-        /// "AUG" -> MET
-        /// </summary>
-        /// <param name="codon">String representing a DNA Codon</param>
-        /// <returns>DNA Codon</returns>
-        public static RnaCodon getRnaCodon(string codon)
-        {
-            char[] charArr = codon.ToCharArray();
-            List<RNA> rnaList = new List<RNA>();
-            foreach (char b in charArr)
-            {
-                rnaList.Add(GeneticMatcher.matchRnaB(b));
-            }
-            var cod = new RnaCodon(rnaList[0], rnaList[1], rnaList[2]);
-            return cod;
-        }
-    }
-
-    //TODO: Codon -> AA methods
-
-    /// <summary>
-    /// Struct representing a DNA Codon
-    /// </summary>
-    public struct DnaCodon
-    {
-        DNA _fp;
-        DNA _sp;
-        DNA _tp;
-
-        public DnaCodon(DNA _fp, DNA _sp, DNA _tp)
-        {
-            this._fp = _fp;
-            this._sp = _sp;
-            this._tp = _tp;
-        }
-
-        public DNA Fp
-        {
-            get
-            {
-                return _fp;
-            }
-
-            set
-            {
-                _fp = value;
-            }
-        }
-
-        public DNA Sp
-        {
-            get
-            {
-                return _sp;
-            }
-
-            set
-            {
-                _sp = value;
-            }
-        }
-
-        public DNA Tp
-        {
-            get
-            {
-                return _tp;
-            }
-
-            set
-            {
-                _tp = value;
-            }
-        }
-
-        public AA toAmino()
-        {
-            throw new NotImplementedException();
-        }
-
-    }
-
-    /// <summary>
-    /// Struct Representing a RNA Codon
-    /// </summary>
-    public struct RnaCodon
-    {
-        RNA _fp;
-        RNA _sp;
-        RNA _tp;
-
-        public RnaCodon(RNA _fp, RNA _sp, RNA _tp)
-        {
-            this._fp = _fp;
-            this._sp = _sp;
-            this._tp = _tp;
+            Fp = fp;
+            Sp = sp;
+            Tp = tp;
         }
 
         public RNA Fp
         {
             get
             {
-                return _fp;
+                return fp;
             }
 
             set
             {
-                _fp = value;
+                fp = value;
             }
         }
 
@@ -941,12 +36,12 @@ namespace DRPTranslatorCS.Symbols
         {
             get
             {
-                return _sp;
+                return sp;
             }
 
             set
             {
-                _sp = value;
+                sp = value;
             }
         }
 
@@ -954,18 +49,80 @@ namespace DRPTranslatorCS.Symbols
         {
             get
             {
-                return _tp;
+                return tp;
             }
 
             set
             {
-                _tp = value;
+                tp = value;
             }
         }
 
-        public AA toAmino()
+        public List<Codon> GetCodonList(string rnaSeq)
         {
-            throw new NotImplementedException();
+            if (rnaSeq.Length % 3 != 0)
+                throw new IndexOutOfRangeException("The sequence is not divisible by 3");
+
+            List<string> strCodons = (from Match m in Regex.Matches(rnaSeq, @"\.{3}") select m.Value).ToList();
+            List<Codon> codons = new List<Codon>();
+            foreach (string rBase in strCodons)
+            {
+                codons.Add(new Codon(GeneticMatcher.MatchRnaB(rBase[0]),
+                                     GeneticMatcher.MatchRnaB(rBase[1]),
+                                     GeneticMatcher.MatchRnaB(rBase[2])));
+            }
+            return codons;
         }
+
+        public string GetCodonSeqString(List<Codon> codons)
+        {
+            string seq = "";
+            foreach (Codon codon in codons)
+            {
+                if (codons.Count == 1)
+                {
+                    seq += codon.ToString();
+                }
+                else if (codons.IndexOf(codon) == codons.Count - 1)
+                {
+                    seq += codon.ToString();
+                }
+                else
+                {
+                    seq += codon.ToString() + "-";
+                }
+            }
+            return seq;
+        }
+
+        public override string ToString()
+        {
+            return @"" + Fp + Sp + Tp;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            Codon cod = obj as Codon;
+            if (Fp == cod.Fp && Sp == cod.Sp && Tp == cod.Tp)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+
+
+        }
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+
     }
+
+
 }

--- a/src/translators/DnaTranslator.cs
+++ b/src/translators/DnaTranslator.cs
@@ -58,7 +58,7 @@ namespace DRPTranslatorCS.Translators
             string returnSeq = "";
             foreach (char dnaBase in dna)
             {
-                dnaList.Add(GeneticMatcher.matchDnaB(dnaBase));
+                dnaList.Add(GeneticMatcher.MatchDnaB(dnaBase));
             }
             foreach (char dnaBase in dnaList)
             {
@@ -76,8 +76,16 @@ namespace DRPTranslatorCS.Translators
         /// <returns></returns>
         public string equivDA(string dna)
         {
-            List<DnaCodon> dnaCodList = new List<DnaCodon>(Codon.getDnaCodonList(dna));
-            return Codon.getDnaCodonSeqStr(dnaCodList);
+            string rna = dna.Replace('T', 'U');
+            Codon cod = new Codon();
+            List<Codon> codons = cod.GetCodonList(rna);
+            List<AA> aminos = GeneticMatcher.MatchAACod(codons);
+            string seq = "";
+            foreach (AA amino in aminos)
+            {
+                seq += amino.ToString();
+            }
+            return seq;
         }
 
         /// <summary>
@@ -127,8 +135,21 @@ namespace DRPTranslatorCS.Translators
         /// <returns></returns>
         public string transDA(string dna)
         {
-            List<DnaCodon> dnaCodList = new List<DnaCodon>(Codon.getDnaCodonList(compDD(dna)));
-            return Codon.getDnaCodonSeqStr(dnaCodList);
+            string equivRna = dna.Replace('T', 'U');
+            string opRna = "";
+            foreach (char eqRnaB in equivRna)
+            {
+                opRna += GeneticMatcher.MatchOpositeRnaB(eqRnaB);
+            }
+            Codon cod = new Codon();
+            List<Codon> codons = cod.GetCodonList(opRna);
+            List<AA> aminos = GeneticMatcher.MatchAACod(codons);
+            string seq = "";
+            foreach (AA amino in aminos)
+            {
+                seq += amino.ToString();
+            }
+            return seq;
         }
 
         /// <summary>


### PR DESCRIPTION
Deleted **DnaCodon** and **RnaCodon** for something more close to the reality just a class named Codon which is composed of RNA, any previous _DnaCodon_ methods or interactions were simply passed out as _DNA_ -> _RNA_ -> _AA_ (when needed) Implemented custom **Equals()** and **ToString()** allowing to delete a bunch of code which was clearly unnecesary.
